### PR TITLE
Generate Procfile on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ end
 require 'capistrano/twingly/upstart'
 
 # config/deploy.rb
+set :procfile_contents, -> {
+  "web: chruby-exec #{fetch(:chruby_ruby)} -- bundle exec " <<
+  "thin start -S /tmp/#{fetch(:app_name)}.thin-1.sock -e #{fetch(:stage)}"
+}
+
 namespace :deploy do
   desc 'Start application'
   task :start do

--- a/lib/capistrano/twingly/tasks/upstart.rake
+++ b/lib/capistrano/twingly/tasks/upstart.rake
@@ -7,4 +7,24 @@ namespace :deploy do
       end
     end
   end
+
+  namespace :foreman do
+    desc 'Upload Procfile to server'
+    task :upload_procfile do
+      on roles(:app) do
+        upload! 'config/foreman/Procfile', "#{fetch(:deploy_to)}/current/Procfile"
+      end
+    end
+
+    desc 'Generate Procfile'
+    task  :generate_procfile do
+      Dir.mkdir('config/foreman') unless Dir.exist?('config/foreman')
+      conf = File.open('config/foreman/Procfile', 'w')
+      conf << "#{fetch(:procfile_contents)}\n"
+      conf.close
+    end
+  end
+
+  before 'deploy:export_upstart', 'deploy:foreman:upload_procfile'
+  before 'deploy:foreman:upload_procfile', 'deploy:foreman:generate_procfile'
 end


### PR DESCRIPTION
I think we can generate the Procfile in the same way as the Nginx config. Procfile is only used during deploy by foreman. The benefit is that there is one place less were we have to change the app name and Ruby version.
