### PR TITLE
Create log directory when deploying

### DIFF
--- a/lib/capistrano/twingly/tasks/upstart.rake
+++ b/lib/capistrano/twingly/tasks/upstart.rake
@@ -12,7 +12,7 @@ namespace :deploy do
   task :create_log_directory do
     on roles(:app) do
       within current_path do
-        execute 'mkdir', '-p', "#{shared_path}/log"
+        execute :mkdir, '-p', "#{shared_path}/log"
       end
     end
   end


### PR DESCRIPTION
The log directory was created automatically by Capistrano 2, but not in version 3. Added a rake task that creates it before starting the app.

~~Warning: Not tested yet.~~

Tested in Chapman by specifying this branch in the Gemfile. It works, and Chapman is started correctly.
