### PR TITLE
Send process output to syslog

### DIFF
--- a/lib/capistrano/twingly/tasks/upstart.rake
+++ b/lib/capistrano/twingly/tasks/upstart.rake
@@ -33,9 +33,12 @@ namespace :deploy do
     desc 'Generate Procfile'
     task  :generate_procfile do
       Dir.mkdir('tmp') unless Dir.exist?('tmp')
-      conf = File.open('tmp/Procfile', 'w')
-      conf << "#{fetch(:procfile_contents)}\n"
-      conf.close
+
+      File.open('tmp/Procfile', 'w') do |conf|
+        fetch(:procfile_contents).each_line do |line|
+          conf.puts "#{line.chomp} 2>&1 | logger -t #{fetch(:app_name)}"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Upstart does not log to syslog (it logs to the kernel ring buffer, [explanation on askubuntu](http://askubuntu.com/a/490900)) which means its logs cannot be sent to Papertrail.

This change redirect all processes output to logger which writes it to the syslog.