### PR TITLE
Each server can have different Procfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,20 +103,18 @@ namespace :deploy do
 end
 ```
 
-It's also possible to use a different Procfile for each host:
+It's also possible to use a different Procfile for each host by setting `procfile_contents` to a Hash:
 
 ```ruby
 # config/deploy.rb
-set :procfile_contents_by_host, -> {
-  procfiles_by_host = {}
+set :procfile_contents, -> {
+  servers = fetch(:servers_from_srv_record)
 
-  fetch(:servers_from_srv_record).each do |hostname|
+  servers.each_with_object({}) do |hostname, procfiles_by_host|
     contents = "web: CURRENT_HOST=#{hostname} bundle exec puma"
 
-    procfile_by_host[hostname] = contents
+    procfiles_by_host[hostname] = contents
   end
-
-  procfiles_by_host
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ namespace :deploy do
 end
 ```
 
+It's also possible to use a different Procfile for each host:
+
+```ruby
+# config/deploy.rb
+set :procfile_contents_by_host, -> {
+  procfiles_by_host = {}
+
+  fetch(:servers_from_srv_record).each do |hostname|
+    contents = "web: CURRENT_HOST=#{hostname} bundle exec puma"
+
+    procfile_by_host[hostname] = contents
+  end
+
+  procfiles_by_host
+}
+```
+
 ### Tag deploys in Git
 
 ```Ruby

--- a/lib/capistrano/twingly/tasks/upstart.rake
+++ b/lib/capistrano/twingly/tasks/upstart.rake
@@ -34,18 +34,18 @@ namespace :deploy do
     task  :generate_procfile do
       Dir.mkdir('tmp') unless Dir.exist?('tmp')
 
-      procfile_contents_by_host = fetch(:procfile_contents_by_host)
+      procfile_contents = fetch(:procfile_contents)
 
       on roles(:app) do |host|
-        procfile_contents =
-          if procfile_contents_by_host
-            procfile_contents_by_host.fetch(host.hostname)
+        procfile_contents_string =
+          if procfile_contents.is_a?(Hash)
+            procfile_contents.fetch(host.hostname)
           else
-            fetch(:procfile_contents)
+            procfile_contents
           end
 
         File.open("tmp/Procfile_#{host.hostname}", 'w') do |conf|
-          procfile_contents.each_line do |line|
+          procfile_contents_string.each_line do |line|
             conf.puts "#{line.chomp} 2>&1 | logger -t #{fetch(:app_name)}"
           end
         end


### PR DESCRIPTION
The task `generate_procfile` always generates separate Procfiles, one per server (`tmp/Procfile_<hostname>`).

* If `procfile_contents` is set to a string, all generated Procfiles will have the same contents.
* If `procfile_contents` is set to a Hash, each Procfile will read its content from `procfile_contents[<hostname>]`.

The user of capistrano-twingly will have to populate the `procfile_contents` hash themselves, as in the example in the readme.

**Edit:** Updated description with the changes in https://github.com/twingly/capistrano-twingly/pull/43/commits/86acc7a518d273415307dee7d8e35ea54eb850e8