### PR TITLE
Generate systemd instead of upstart configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
     - rvm: ruby-head
   fast_finish: true
 before_install:
-  - gem install bundler -v '<2.0'
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 cache: bundler
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - rvm: ruby-head
   fast_finish: true
 before_install:
-  - gem install bundler
+  - gem install bundler -v '<2.0'
 cache: bundler
 notifications:
   email: false

--- a/lib/capistrano/twingly.rb
+++ b/lib/capistrano/twingly.rb
@@ -13,7 +13,7 @@ require "capistrano/bundler"
 
 # Twingly tasks
 require "capistrano/twingly/nginx"
-require "capistrano/twingly/upstart"
+require "capistrano/twingly/systemd"
 require "capistrano/twingly/tag_deploy_in_git"
 require "capistrano/twingly/current_git_branch"
 require "capistrano/twingly/servers_from_srv_record"

--- a/lib/capistrano/twingly/systemd.rb
+++ b/lib/capistrano/twingly/systemd.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../tasks/systemd.rake", __FILE__)

--- a/lib/capistrano/twingly/upstart.rb
+++ b/lib/capistrano/twingly/upstart.rb
@@ -1,1 +1,0 @@
-load File.expand_path("../tasks/upstart.rake", __FILE__)


### PR DESCRIPTION
The service needs to be stopped when installing the new config files, otherwise the service will still be active, but report "Loaded: not-found".
See https://github.com/twingly/capistrano-twingly/issues/31#issuecomment-486559472

For this to work we also need to make sure the deploy user is allowed to run these commands on the appservers.

Related to #45

### Todo

- [ ] Figure out how to deploy apps to both Ubuntu 14.04/18.04, see comments in #45
- [ ] Update README
- [ ] Fix the tests