### PR TITLE
Generate systemd config in addition to upstart

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ matrix:
     - rvm: ruby-head
   fast_finish: true
 before_install:
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 cache: bundler
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -109,15 +109,13 @@ end
 
 ### Fetch servers from SRV record
 
-*Note: Each server needs to either have the `systemd` or `upstart` role (in addition to `app`) depending on which service management system is used on the server.*
-
 ```Ruby
 # Capfile
 require 'capistrano/twingly/servers_from_srv_record'
 
 # config/deploy/production.rb
 fetch(:servers_from_srv_record).each do |hostname|
-  server hostname, user: 'deploy', roles: %w{app systemd}
+  server hostname, user: 'deploy', roles: %w{app}
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,44 +74,6 @@ set :procfile_contents, -> {
 }
 
 namespace :deploy do
-  desc "Start application"
-  task :start do
-    invoke "deploy:export_service"
-
-    on roles(:upstart) do
-      sudo :start, fetch(:application)
-    end
-
-    on roles(:systemd) do
-      sudo :systemctl, "start #{fetch(:application)}.target"
-    end
-  end
-
-  desc "Restart application"
-  task :restart do
-    invoke "deploy:export_service"
-
-    on roles(:upstart) do
-      execute "sudo restart #{fetch(:application)} || sudo start #{fetch(:application)}"
-    end
-
-    on roles(:systemd) do
-      application = fetch(:application)
-      execute "sudo systemctl restart #{application}.target || sudo systemctl start #{application}.target"
-    end
-  end
-
-  desc "Stop application"
-  task :stop do
-    on roles(:upstart) do
-      sudo :stop, fetch(:application)
-    end
-
-    on roles(:systemd) do
-      sudo :systemctl, "stop #{fetch(:application)}.target"
-    end
-  end
-
   after :stop, 'deploy:disable_autostart'
   after :start, 'deploy:enable_autostart'
   after :restart, 'deploy:enable_autostart'

--- a/lib/capistrano/twingly.rb
+++ b/lib/capistrano/twingly.rb
@@ -13,7 +13,7 @@ require "capistrano/bundler"
 
 # Twingly tasks
 require "capistrano/twingly/nginx"
-require "capistrano/twingly/upstart"
+require "capistrano/twingly/service"
 require "capistrano/twingly/tag_deploy_in_git"
 require "capistrano/twingly/current_git_branch"
 require "capistrano/twingly/servers_from_srv_record"

--- a/lib/capistrano/twingly/service.rb
+++ b/lib/capistrano/twingly/service.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../tasks/service.rake", __FILE__)

--- a/lib/capistrano/twingly/tasks/service.rake
+++ b/lib/capistrano/twingly/tasks/service.rake
@@ -14,7 +14,7 @@ namespace :deploy do
   end
 
   desc 'Export service script'
-  task export_service: %w[deploy:lookup_server_service_manager deploy:foreman:upload_procfile] do
+  task export_service: %w[lookup_server_service_manager foreman:upload_procfile] do
     on roles(:upstart) do
       within current_path do
         sudo fetch(:chruby_exec), "#{fetch(:chruby_ruby)} -- #{fetch(:bundle_binstubs)}/foreman export upstart /etc/init -a #{fetch(:application)} -u \`whoami\` -l #{shared_path}/log"
@@ -33,7 +33,7 @@ namespace :deploy do
   end
 
   desc "Start application"
-  task start: "deploy:lookup_server_service_manager" do
+  task start: :lookup_server_service_manager do
     invoke "deploy:export_service"
 
     on roles(:upstart) do
@@ -46,7 +46,7 @@ namespace :deploy do
   end
 
   desc "Restart application"
-  task restart: "deploy:lookup_server_service_manager" do
+  task restart: :lookup_server_service_manager do
     invoke "deploy:export_service"
 
     on roles(:upstart) do
@@ -60,7 +60,7 @@ namespace :deploy do
   end
 
   desc "Stop application"
-  task stop: "deploy:lookup_server_service_manager" do
+  task stop: :lookup_server_service_manager do
     on roles(:upstart) do
       sudo :stop, fetch(:application)
     end
@@ -70,7 +70,7 @@ namespace :deploy do
     end
   end
 
-  task disable_autostart: "deploy:lookup_server_service_manager" do
+  task disable_autostart: :lookup_server_service_manager do
     on roles(:upstart) do
       execute "/bin/echo manual | sudo /usr/bin/tee /etc/init/#{fetch(:application)}.override"
     end
@@ -80,7 +80,7 @@ namespace :deploy do
     end
   end
 
-  task enable_autostart: "deploy:lookup_server_service_manager" do
+  task enable_autostart: :lookup_server_service_manager do
     on roles(:upstart) do
       execute "/bin/echo | sudo /usr/bin/tee /etc/init/#{fetch(:application)}.override"
     end
@@ -92,7 +92,7 @@ namespace :deploy do
 
   namespace :foreman do
     desc 'Upload Procfile to server'
-    task upload_procfile: "deploy:foreman:generate_procfile" do
+    task upload_procfile: :generate_procfile do
       on roles(:app) do |host|
         upload! "tmp/Procfile_#{host.hostname}", "#{fetch(:deploy_to)}/current/Procfile"
       end

--- a/lib/capistrano/twingly/tasks/service.rake
+++ b/lib/capistrano/twingly/tasks/service.rake
@@ -3,13 +3,13 @@ namespace :deploy do
 
   desc 'Lookup which service manager is used on each server'
   task :lookup_server_service_manager do
+    systemd_pid = 1
+
     on roles(:app) do |host|
-      systemd_is_installed = execute "command -v systemctl",
-                                     raise_on_non_zero_exit: false
+      service_manager_name =
+        capture "ps -p#{systemd_pid} co command | grep systemd || echo upstart"
 
-      role = systemd_is_installed ? :systemd : :upstart
-
-      server(host).add_role(role)
+      server(host).add_role(service_manager_name.to_sym)
     end
   end
 

--- a/lib/capistrano/twingly/tasks/service.rake
+++ b/lib/capistrano/twingly/tasks/service.rake
@@ -20,6 +20,44 @@ namespace :deploy do
     end
   end
 
+  desc "Start application"
+  task :start do
+    invoke "deploy:export_service"
+
+    on roles(:upstart) do
+      sudo :start, fetch(:application)
+    end
+
+    on roles(:systemd) do
+      sudo :systemctl, "start #{fetch(:application)}.target"
+    end
+  end
+
+  desc "Restart application"
+  task :restart do
+    invoke "deploy:export_service"
+
+    on roles(:upstart) do
+      execute "sudo restart #{fetch(:application)} || sudo start #{fetch(:application)}"
+    end
+
+    on roles(:systemd) do
+      application = fetch(:application)
+      execute "sudo systemctl restart #{application}.target || sudo systemctl start #{application}.target"
+    end
+  end
+
+  desc "Stop application"
+  task :stop do
+    on roles(:upstart) do
+      sudo :stop, fetch(:application)
+    end
+
+    on roles(:systemd) do
+      sudo :systemctl, "stop #{fetch(:application)}.target"
+    end
+  end
+
   task :disable_autostart do
     on roles(:upstart) do
       execute "/bin/echo manual | sudo /usr/bin/tee /etc/init/#{fetch(:application)}.override"

--- a/lib/capistrano/twingly/tasks/service.rake
+++ b/lib/capistrano/twingly/tasks/service.rake
@@ -14,7 +14,7 @@ namespace :deploy do
   end
 
   desc 'Export service script'
-  task export_service: "deploy:lookup_server_service_manager" do
+  task export_service: %w[deploy:lookup_server_service_manager deploy:foreman:upload_procfile] do
     on roles(:upstart) do
       within current_path do
         sudo fetch(:chruby_exec), "#{fetch(:chruby_ruby)} -- #{fetch(:bundle_binstubs)}/foreman export upstart /etc/init -a #{fetch(:application)} -u \`whoami\` -l #{shared_path}/log"
@@ -92,7 +92,7 @@ namespace :deploy do
 
   namespace :foreman do
     desc 'Upload Procfile to server'
-    task :upload_procfile do
+    task upload_procfile: "deploy:foreman:generate_procfile" do
       on roles(:app) do |host|
         upload! "tmp/Procfile_#{host.hostname}", "#{fetch(:deploy_to)}/current/Procfile"
       end
@@ -120,7 +120,4 @@ namespace :deploy do
       end
     end
   end
-
-  before 'deploy:export_service', 'deploy:foreman:upload_procfile'
-  before 'deploy:foreman:upload_procfile', 'deploy:foreman:generate_procfile'
 end

--- a/lib/capistrano/twingly/upstart.rb
+++ b/lib/capistrano/twingly/upstart.rb
@@ -1,1 +1,0 @@
-load File.expand_path("../tasks/upstart.rake", __FILE__)


### PR DESCRIPTION
From https://github.com/twingly/capistrano-twingly/issues/45#issuecomment-486665525 and the comments below it.

close #45

### Todo

- [x] ~~Load servers from multiple SRV records~~ **Edit**: Solved it like this instead: 8df07a9