### PR TITLE
Make sure systemd target is loaded before trying to stop it

### DIFF
--- a/lib/capistrano/twingly/tasks/service.rake
+++ b/lib/capistrano/twingly/tasks/service.rake
@@ -22,7 +22,12 @@ namespace :deploy do
     end
 
     on roles(:systemd) do
-      sudo :systemctl, "stop #{fetch(:application)}.target"
+      load_state =
+        capture "systemctl show #{fetch(:application)}.target -p LoadState --value"
+
+      if load_state == "loaded"
+        sudo :systemctl, "stop #{fetch(:application)}.target"
+      end
 
       within current_path do
         sudo fetch(:chruby_exec), "#{fetch(:chruby_ruby)} -- #{fetch(:bundle_binstubs)}/foreman export systemd /etc/systemd/system -a #{fetch(:application)} -u \`whoami\` -l #{shared_path}/log"


### PR DESCRIPTION
During the initial deploy there is no systemd target to load which means the command `systemctl stop` results in an error.

Now we check that the target exists before running `systemctl stop`.

The reason for stopping it in the first place is to make sure no old processes are left behind, which could otherwise happend if we remove/rename one of the processes in the procfile.
See https://github.com/twingly/capistrano-twingly/issues/31#issuecomment-486578861

close #49