### PR TITLE
Newer Ruby on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.4.2
+  - 2.6.5
   - ruby-head
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 rvm:
   - 2.6.5
   - ruby-head


### PR DESCRIPTION
Removed the deprecated `sudo: false` line as well.

Due to there only being one test in this project I skipped adding the `dist: bionic` line, that way Travis will automatically update us to the next distribution automatically when the time comes.