### PR TITLE
Ruby 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: ruby
 rvm:
-  - 2.6.5
+  - 2.7.1
   - ruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
   fast_finish: true
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
 cache: bundler
 notifications:
   email: false

--- a/capistrano-twingly.gemspec
+++ b/capistrano-twingly.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ed25519", ">= 1.2", "< 1.3"
   spec.add_dependency "bcrypt_pbkdf", ">= 1.0", "< 2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
Dropped Bundler from gemspec as we, internally, only use Ruby 2.7 which comes with bundler pre-installed.