### PR TITLE
Update Capistrano

### DIFF
--- a/capistrano-twingly.gemspec
+++ b/capistrano-twingly.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capistrano", "~> 3.14"
-  spec.add_dependency "capistrano-bundler", "2.0"
+  spec.add_dependency "capistrano-bundler", "~> 2.0"
   spec.add_dependency "capistrano-chruby", "0.1.2"
   spec.add_dependency "foreman", "~> 0.82"
   spec.add_dependency "net-ssh", "~> 5.0"

--- a/capistrano-twingly.gemspec
+++ b/capistrano-twingly.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", "~> 3.6.0"
-  spec.add_dependency "capistrano-bundler", "1.1.4"
+  spec.add_dependency "capistrano", "~> 3.14"
+  spec.add_dependency "capistrano-bundler", "2.0"
   spec.add_dependency "capistrano-chruby", "0.1.2"
   spec.add_dependency "foreman", "~> 0.82"
   spec.add_dependency "net-ssh", "~> 5.0"

--- a/lib/capistrano/twingly/tasks/service.rake
+++ b/lib/capistrano/twingly/tasks/service.rake
@@ -1,6 +1,4 @@
 namespace :deploy do
-  set :bundle_binstubs, -> { shared_path.join('bin') }
-
   desc 'Lookup which service manager is used on each server'
   task :lookup_server_service_manager do
     init_system_pid = 1
@@ -15,6 +13,8 @@ namespace :deploy do
 
   desc 'Export service script'
   task export_service: %w[lookup_server_service_manager foreman:upload_procfile] do
+    set :bundle_binstubs, -> { shared_path.join('bin') }
+
     on roles(:upstart) do
       within current_path do
         sudo fetch(:chruby_exec), "#{fetch(:chruby_ruby)} -- #{fetch(:bundle_binstubs)}/foreman export upstart /etc/init -a #{fetch(:application)} -u \`whoami\` -l #{shared_path}/log"


### PR DESCRIPTION
The previous versions were very old (2015 and 2016). 

The update also resolves Ruby 2.7 warnings like https://github.com/twingly/blantyre/issues/101.