### PR TITLE
Explicitly use the git plugin

### DIFF
--- a/lib/capistrano/twingly.rb
+++ b/lib/capistrano/twingly.rb
@@ -4,6 +4,9 @@ require "capistrano/setup"
 # Include default deployment tasks
 require "capistrano/deploy"
 
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
 # Console to the servers
 require "capistrano/console"
 


### PR DESCRIPTION
Capistrano has, since 3.7.0 (https://github.com/capistrano/capistrano/blob/v3.7.0/UPGRADING-3.7.md#the-scm-variable-is-deprecated), deprecated the behavior of git being the default SCM.

Seeing that we require, at the time of writing, Capistrano 3.14.0, this seems like the sound thing to do here.

The deprecation message reads as:

```
[Deprecation Notice] Future versions of Capistrano will not load the Git SCM
plugin by default. To silence this deprecation warning, add the following to
your Capfile after `require "capistrano/deploy"`:

    require "capistrano/scm/git"
    install_plugin Capistrano::SCM::Git
```