### PR TITLE
Use net-ssh ~> 7.0

### DIFF
--- a/capistrano-twingly.gemspec
+++ b/capistrano-twingly.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capistrano-bundler", "~> 2.0"
   spec.add_dependency "capistrano-chruby", "0.1.2"
   spec.add_dependency "foreman", "~> 0.82"
-  spec.add_dependency "net-ssh", "~> 5.0"
+  spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "ed25519", ">= 1.2", "< 1.3"
   spec.add_dependency "bcrypt_pbkdf", ">= 1.0", "< 2.0"
 


### PR DESCRIPTION
The deployment of norrstrom failed:

```
Caused by:
OpenSSL::PKey::PKeyError: rsa#set_key= is incompatible with OpenSSL 3.0
```

This was fixed in net-ssh 7, according to: https://stackoverflow.com/a/72075830.

The latest versions of net-ssh are not yet included in the [changelog](https://github.com/net-ssh/net-ssh/blob/v7.0.1/CHANGES.txt), but I used this new version of capistrano-twingly in the test repo and the deployment worked fine. Since we use capistrano in the same way in all our projects, this test should suffice.