### PR TITLE
Use datacenter gateway as fallback DNS server

### DIFF
--- a/lib/capistrano/twingly/tasks/servers_from_srv_record.rake
+++ b/lib/capistrano/twingly/tasks/servers_from_srv_record.rake
@@ -3,14 +3,25 @@ require 'resolv'
 SRV_RECORDS = %w[
   _rubyapps._tcp.sth.twingly.network
 ]
+FALLBACK_DNS_SERVER = "gateway.sth.twingly.network"
 
-resolver = Resolv::DNS.new
+def lookup_srv_records(resolver: Resolv::DNS.new)
+  SRV_RECORDS.map do |srv_record|
+    resolver.getresources(srv_record, Resolv::DNS::Resource::IN::SRV)
+  end.flatten.map(&:target).map(&:to_s)
+end
 
-servers = SRV_RECORDS.map do |srv_record|
-  resolver.getresources(srv_record, Resolv::DNS::Resource::IN::SRV)
-end.flatten.map(&:target).map(&:to_s)
+servers = lookup_srv_records
 
-raise "Can't find any servers, no records for #{SRV_RECORDS}" if servers.empty?
+# Query datacenter gateway directly if local DNS server is unable to find the SRV records
+if servers.empty?
+  datacenter_dns_server_address = Resolv.getaddress(FALLBACK_DNS_SERVER)
+
+  resolver = Resolv::DNS.new(nameserver: datacenter_dns_server_address)
+  servers  = lookup_srv_records(resolver: resolver)
+
+  raise "Can't find any servers, no records for #{SRV_RECORDS}" if servers.empty?
+end
 
 set :servers_from_srv_record, servers
 


### PR DESCRIPTION
This fix makes sure that the devs which has upgraded to macOS 13 can access the SRV records again, by querying the DNS server in the datacenter directly, if our local DNS server fails to find the records. (Our local DNS server, dnsmasq, queries the DNS in the datacenter behind the scenes anyway.)

Would be nice if someone that uses macOS 13 could test this. One can test it in the following fashion:

* Check out this branch locally
* In the [twingly/test](https://github.com/twingly/test) repo:
  * Point the Gemfile there to your local checked out version of `capistano-twingly` (for example: `gem "capistrano-twingly", path: "../capistrano-twingly"`)
  * Run `bundle install`
  * Run `bundle exec cap production list:servers`. If you get some server names in the output, it works :)

*Note that you need to point `gateway.sth.twingly.network` to the correct address in your hosts file for this to work.*

close #68