### PR TITLE
Make it possible to set `X-Forwarded-Proto` header to `https`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ require 'capistrano/twingly/nginx'
 set :app_name, 'contest-bamba'
 set :server_names, %w(bamba.bloggportalen.se)
 set :use_https, true # Optional
+set :forwarded_protocol_is_https, true # Optional
 
 namespace :deploy do
   after :finishing, 'deploy:nginx:generate_config'

--- a/lib/capistrano/twingly/tasks/nginx.rake
+++ b/lib/capistrano/twingly/tasks/nginx.rake
@@ -9,6 +9,7 @@ namespace :deploy do
       server_names = fetch(:server_names)
 
       https_port = ":443" if fetch(:use_https)
+      forwarded_protocol_is_https = fetch(:forwarded_protocol_is_https)
 
       conf = File.open('tmp/site.conf', 'w')
       conf << %Q{
@@ -42,6 +43,7 @@ namespace :deploy do
             proxy_set_header   Host             $host#{https_port};
             proxy_set_header   X-Real-IP        $remote_addr;
             proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            #{forwarded_protocol_is_https ? "proxy_set_header   X-Forwarded-Proto https;" : ""}
           }
         }\n}
         conf.close


### PR DESCRIPTION
This header is apparently needed if we forward a HTTPS request, see #41. Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto

I didn't bother to make this work for all possible headers we might want to set in the future. We don't use the nginx functionality of this gem that much, and hopefully we'll be able to switch to a better type of deployment sometime in the future anyway.

close #41