### PR TITLE
Run CI on latest Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.7.6, 3.0.4, 3.1.2]
+        ruby: [3.1, 3.2, 3.3]
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Ruby 2.7 and 3.0 have reached EOL.