### PR TITLE
Support Ruby >= 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [3.1, 3.2, 3.3]
+        ruby: [3.1, 3.2, 3.3, 3.4]
 
     steps:
       - name: Checkout Code

--- a/capistrano-twingly.gemspec
+++ b/capistrano-twingly.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "capistrano", "~> 3.14"
   spec.add_dependency "capistrano-bundler", "~> 2.0"
   spec.add_dependency "capistrano-chruby", "0.1.2"
-  spec.add_dependency "foreman", "~> 0.82"
+  spec.add_dependency "foreman", "~> 0.88"
   spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "ed25519", ">= 1.2", "< 1.3"
   spec.add_dependency "bcrypt_pbkdf", ">= 1.0", "< 2.0"


### PR DESCRIPTION
The method `File.exists?` was removed in Ruby 3.2 [1]. This method was replaced in foreman 0.88.0 [2].

The CI workflow was also updated to run on Ruby 3.4.

[1]: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
[2]: https://github.com/ddollar/foreman/blob/3a262714030a83a59388a48ffdb2e93cdac12388/Changelog.md?plain=1#L22